### PR TITLE
Revert "Bump flask from 1.1.1 to 2.3.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.2
+Flask==1.1.1
 gunicorn==19.9.0
 PyYAML==5.4
 requests==2.22.0


### PR DESCRIPTION
Reverts galaxyecology/webhook_SPIPOLL_Flash#3

That broke our deployment with:

> fatal: [sn06.galaxyproject.eu]: FAILED! => {"changed": false, "cmd": ["/opt/gapars/venv/bin/pip3", "install", "-r", "/opt/gapars/code/requirements.txt"], "msg": "stdout: Collecting Flask==2.3.2 (from -r /opt/gapars/code/requirements.txt (line 1))\n\n:stderr:   Could not find a version that satisfies the requirement Flask==2.3.2 (from -r /opt/gapars/code/requirements.txt (line 1)) (from versions: 0.1, 0.2, 0.3, 0.3.1, 0.4, 0.5, 0.5.1, 0.5.2, 0.6, 0.6.1, 0.7, 0.7.1, 0.7.2, 0.8, 0.8.1, 0.9, 0.10, 0.10.1, 0.11, 0.11.1, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 2.0.0rc1, 2.0.0rc2, 2.0.0, 2.0.1, 2.0.2, 2.0.3)\nNo matching distribution found for Flask==2.3.2 (from -r /opt/gapars/code/requirements.txt (line 1))\nYou are using pip version 9.0.3, however version 23.1.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n"}